### PR TITLE
set windows-size for headless-mode to support space consuming modern themes like Saga

### DIFF
--- a/primefaces-selenium-core/src/main/java/org/primefaces/extensions/selenium/PrimeSelenium.java
+++ b/primefaces-selenium-core/src/main/java/org/primefaces/extensions/selenium/PrimeSelenium.java
@@ -27,6 +27,10 @@ import org.primefaces.extensions.selenium.spi.WebDriverProvider;
 
 public final class PrimeSelenium {
 
+    private static final String HEADLESS_MODE_SYSPROP_NAME = "webdriver.headless";
+
+    private static final String HEADLESS_MODE_SYSPROP_VAL_DEFAULT = "false";
+
     private PrimeSelenium() {
         super();
     }
@@ -234,5 +238,9 @@ public final class PrimeSelenium {
         else {
             return false;
         }
+    }
+
+    public static boolean isHeadless() {
+        return Boolean.parseBoolean(System.getProperty(HEADLESS_MODE_SYSPROP_NAME, HEADLESS_MODE_SYSPROP_VAL_DEFAULT));
     }
 }

--- a/primefaces-selenium-core/src/main/java/org/primefaces/extensions/selenium/spi/WebDriverProvider.java
+++ b/primefaces-selenium-core/src/main/java/org/primefaces/extensions/selenium/spi/WebDriverProvider.java
@@ -15,8 +15,10 @@
  */
 package org.primefaces.extensions.selenium.spi;
 
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.primefaces.extensions.selenium.PrimeSelenium;
 import org.primefaces.extensions.selenium.internal.ConfigProvider;
 import org.primefaces.extensions.selenium.internal.OnloadScriptsEventListener;
 
@@ -38,6 +40,14 @@ public class WebDriverProvider {
             PrimeSeleniumAdapter adapter = ConfigProvider.getInstance().getAdapter();
 
             driver = adapter.createWebDriver();
+
+            if (PrimeSelenium.isHeadless()) {
+                /*
+                 * Define window-size for headless-mode. Selenium WebDriver-default seems to be 800x600. This causes issues with modern themes (eg Saga) which
+                 * use more space for some components. (eg DatePicker-popup)
+                 */
+                driver.manage().window().setSize(new Dimension(1920, 1080));
+            }
 
             EventFiringWebDriver eventDriver = new EventFiringWebDriver(driver);
             eventDriver.register(new OnloadScriptsEventListener());


### PR DESCRIPTION
some of our existing datepicker-test´s fail with saga-theme