### PR TITLE
disable CSS-Animations

### DIFF
--- a/primefaces-selenium-core/src/main/java/org/primefaces/extensions/selenium/internal/component/PrimeFacesSeleniumDummyComponent.java
+++ b/primefaces-selenium-core/src/main/java/org/primefaces/extensions/selenium/internal/component/PrimeFacesSeleniumDummyComponent.java
@@ -31,9 +31,14 @@ public class PrimeFacesSeleniumDummyComponent extends UIComponentBase {
     public PrimeFacesSeleniumDummyComponent() {
         FacesContext context = FacesContext.getCurrentInstance();
         Application application = context.getApplication();
+        // addResource(context, application, "pfselenium.disableanimations.css");
+        addResource(context, application, "pfselenium.core.csp.js");
+    }
+
+    private void addResource(FacesContext context, Application application, String resourceName) {
         UIComponent componentResource = application.createComponent("javax.faces.Output");
-        componentResource.setRendererType(application.getResourceHandler().getRendererTypeForResourceName("pfselenium.core.csp.js"));
-        componentResource.getAttributes().put("name", "pfselenium.core.csp.js");
+        componentResource.setRendererType(application.getResourceHandler().getRendererTypeForResourceName(resourceName));
+        componentResource.getAttributes().put("name", resourceName);
         componentResource.getAttributes().put("library", "primefaces_selenium");
         componentResource.getAttributes().put("target", "head");
         context.getViewRoot().addComponentResource(context, componentResource, "head");

--- a/primefaces-selenium-core/src/main/java/org/primefaces/extensions/selenium/internal/component/PrimeFacesSeleniumDummyComponent.java
+++ b/primefaces-selenium-core/src/main/java/org/primefaces/extensions/selenium/internal/component/PrimeFacesSeleniumDummyComponent.java
@@ -31,7 +31,7 @@ public class PrimeFacesSeleniumDummyComponent extends UIComponentBase {
     public PrimeFacesSeleniumDummyComponent() {
         FacesContext context = FacesContext.getCurrentInstance();
         Application application = context.getApplication();
-        // addResource(context, application, "pfselenium.disableanimations.css");
+        addResource(context, application, "pfselenium.disableanimations.css");
         addResource(context, application, "pfselenium.core.csp.js");
     }
 

--- a/primefaces-selenium-core/src/main/resources/META-INF/resources/primefaces_selenium/pfselenium.disableanimations.css
+++ b/primefaces-selenium-core/src/main/resources/META-INF/resources/primefaces_selenium/pfselenium.disableanimations.css
@@ -1,0 +1,3 @@
+.ui-connected-overlay-enter-active, .ui-connected-overlay-exit-active {
+    transition-duration: 0s;
+}


### PR DESCRIPTION
We may add some switch to toggle css-animations on/off.
For most integration-tests IMO css-animations are not necessary.