### PR TITLE
CSP: Better detection of error message

### DIFF
--- a/primefaces-selenium-components/src/main/java/org/primefaces/extensions/selenium/component/base/AbstractComponent.java
+++ b/primefaces-selenium-components/src/main/java/org/primefaces/extensions/selenium/component/base/AbstractComponent.java
@@ -87,7 +87,7 @@ public abstract class AbstractComponent extends AbstractPrimePageFragment {
                         element.getAttribute("id") + "', '" + event + "')");
         }
         catch (JavascriptException ex) {
-            if (ex.getMessage().contains("javascript error: PrimeFaces.csp.hasRegisteredAjaxifiedEvent is not a function")) {
+            if (ex.getMessage().contains("PrimeFaces.csp.hasRegisteredAjaxifiedEvent is not a function")) {
                 System.err.println("WARNING: 'pfselenium.core.csp.js' missing - not added to the page");
             }
             else {


### PR DESCRIPTION
Today I had an error
"**TypeError**: PrimeFaces.csp.hasRegisteredAjaxifiedEvent is not a function
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: 'falconserv', ip: '127.0.1.1', os.name: 'Linux', os.arch: 'amd64', os.version: '5.4.0-70-generic', java.version: '11.0.10'
Driver info: org.openqa.selenium.firefox.FirefoxDriver
Capabilities {acceptInsecureCerts: true, browserName: firefox, browserVersion: 87.0, javascriptEnabled: true, moz:accessibilityChecks: false, moz:buildID: 20210318103112, moz:geckodriverVersion: 0.29.0, moz:headless: false, moz:processID: 207601, moz:profile: /tmp/rust_mozprofileWwew6T, moz:shutdownTimeout: 60000, moz:useNonSpecCompliantPointerOrigin: false, moz:webdriverClick: true, pageLoadStrategy: normal, platform: LINUX, platformName: LINUX, platformVersion: 5.4.0-70-generic, rotatable: false, setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify}
Session ID: 79611729-5a50-4da6-8784-d18ad355636b" while running my primefaces-selenium tests with Firefox 87.0.

The formulation with "**javascript error**: ..." is incorrect (at least, for this version of Firefox). With new formulation all works correct.

Please, include this fix in 10.x version of primefaces-selenium.

Signed-off-by: Vladimir V. Bychkov <github@bychkov.name>